### PR TITLE
Add memory unit labels for memory and swap

### DIFF
--- a/lib/mem/mem.go
+++ b/lib/mem/mem.go
@@ -12,64 +12,91 @@ type Facter interface {
 	Add(string, interface{})
 }
 
+// addMemoryUnits will convert a memory fact into "fact_mb" and "fact_bytes"
+func addMemoryUnits(f Facter, label string, memory uint64) error {
+	units := map[string]string{
+		"MB": "mb",
+		"B":  "bytes",
+	}
+
+	for unit, unitLabel := range units {
+		factLabel := fmt.Sprintf("%s_%s", label, unitLabel)
+		convertedMemory, _, err := common.ConvertBytesTo(memory, unit)
+		if err != nil {
+			return err
+		}
+
+		f.Add(factLabel, fmt.Sprintf("%.2f", convertedMemory))
+	}
+
+	return nil
+}
+
 // GetMemoryFacts gathers facts related to system memory
 func GetMemoryFacts(f Facter) error {
+	// Get the virtual memory from gopsutil
 	hostVMem, err := m.VirtualMemory()
 	if err != nil {
 		return err
 	}
+
+	// Add a memoryfree fact
 	memFree, unit, err := common.ConvertBytes(hostVMem.Free)
 	if err != nil {
 		return err
 	}
 	f.Add("memoryfree", fmt.Sprintf("%.2f %v", memFree, unit))
 
-	memFreeMB, unit, err := common.ConvertBytesTo(hostVMem.Free, "MB")
+	// Add memoryfree_mb and memoryfree_bytes facts
+	err = addMemoryUnits(f, "memoryfree", hostVMem.Free)
 	if err != nil {
 		return err
 	}
-	f.Add("memoryfree_mb", fmt.Sprintf("%.2f %v", memFreeMB, unit))
 
+	// Add a memorytotal fact
 	memTotal, unit, err := common.ConvertBytes(hostVMem.Total)
 	if err != nil {
 		return err
 	}
 	f.Add("memorysize", fmt.Sprintf("%.2f %v", memTotal, unit))
 
-	memTotalMB, unit, err := common.ConvertBytesTo(hostVMem.Total, "MB")
+	// add memorytotal_mb and memorytotal_bytes facts
+	err = addMemoryUnits(f, "memorysize", hostVMem.Total)
 	if err != nil {
 		return err
 	}
-	f.Add("memorysize_mb", fmt.Sprintf("%.2f %v", memTotalMB, unit))
 
+	// Get the swap information from gopsutil
 	hostSwapMem, err := m.SwapMemory()
 	if err != nil {
 		return err
 	}
 
+	// Add a swapfree fact
 	swapFree, unit, err := common.ConvertBytes(hostSwapMem.Free)
 	if err != nil {
 		return err
 	}
 	f.Add("swapfree", fmt.Sprintf("%.2f %v", swapFree, unit))
 
-	swapFreeMB, unit, err := common.ConvertBytesTo(hostSwapMem.Free, "MB")
+	// Add swapfree_mb and swapfree_bytes facts
+	err = addMemoryUnits(f, "swapfree", hostSwapMem.Free)
 	if err != nil {
 		return err
 	}
-	f.Add("swapfree_mb", fmt.Sprintf("%.2f %v", swapFreeMB, unit))
 
+	// Add a swapsize fact
 	swapTotal, unit, err := common.ConvertBytes(hostSwapMem.Total)
 	if err != nil {
 		return err
 	}
 	f.Add("swapsize", fmt.Sprintf("%.2f %v", swapTotal, unit))
 
-	swapTotalMB, unit, err := common.ConvertBytesTo(hostSwapMem.Total, "MB")
+	// Add swapsize_mb and swapsize_bytes facts
+	err = addMemoryUnits(f, "swapsize", hostSwapMem.Total)
 	if err != nil {
 		return err
 	}
-	f.Add("swapsize_mb", fmt.Sprintf("%.2f %v", swapTotalMB, unit))
 
 	return nil
 }


### PR DESCRIPTION
For #2 

@zstyblik: I made the following changes from https://github.com/jtopjian/go-facter/commit/9149610c4c7306a4cd475a3cc3a4b9e72e69a96d:

* Removed `.00` truncation (using `math.Mod`) because sometimes values such as `4096.00` were still appearing. This is due to the modulo being `.99996` sometimes. If you know of a correct way of truncating the zeros, I can definitely apply it.

* Removed `_gb` and `_kb` facts.

* Fixed the erroneous `swapfree` when it should have been `swapsize`.

Let me know if you see any more issues :)